### PR TITLE
Bugfix, passing on Log nextToken and cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     name="tibber_aws",
     packages=["tibber_aws"],
     install_requires=requirements,
-    version="0.16.2",
+    version="0.16.3",
     description="A python3 library to communicate with Aws",
     python_requires=">=3.7.0",
     author="Tibber",


### PR DESCRIPTION
When iterating, ran until max recursion due to not passing on the actual `nextToken` to log query.

```
2022-12-20 10:11:07,593 - INFO - aws_logs - [<ipython-input-1-1b4c19fab1ff>:228] Found 34 log events searching for pattern={ ( $.event = "Request" ) && ( $.body.price_area = "NL" ) && ( $.body.vehicle_type = "easee charger" ) } in log_group=prod-hem-api, with responseMetadata=None
2022-12-20 10:11:07,593 - INFO - aws_logs - [<ipython-input-1-1b4c19fab1ff>:280] More logs to fetch... Using nextToken, 1/10
2022-12-20 10:11:07,718 - INFO - aws_logs - [<ipython-input-1-1b4c19fab1ff>:228] Found 0 log events searching for pattern={ ( $.event = "Request" ) && ( $.body.price_area = "NL" ) && ( $.body.vehicle_type = "easee charger" ) } in log_group=prod-hem-api, with responseMetadata=None
```